### PR TITLE
Adding protocol for elasticsearch url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,9 @@ RUN rm -f /etc/kibana/kibana.yml
 
 ENV KIBANA_PWD="changeme" \
     ELASTICSEARCH_HOST="elasticsearch" \
-    ELASTICSEARCH_PORT="9200"
-
+    ELASTICSEARCH_PORT="9200" \
+    ELASTICSEARCH_PROTO="http"
+    
 ADD ./src/ /run/
 RUN chmod +x -R /run/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN rm -f /etc/kibana/kibana.yml
 ENV KIBANA_PWD="changeme" \
     ELASTICSEARCH_HOST="elasticsearch" \
     ELASTICSEARCH_PORT="9200" \
-    ELASTICSEARCH_PROTO="http"
+    ELASTICSEARCH_PROTOCOL="http"
     
 ADD ./src/ /run/
 RUN chmod +x -R /run/

--- a/src/miscellaneous/edit_config.sh
+++ b/src/miscellaneous/edit_config.sh
@@ -3,7 +3,7 @@
 # KIBANA PWD
 sed -ri "s|elasticsearch.password:[^\r\n]*|elasticsearch.password: $KIBANA_PWD|" /etc/kibana/kibana.yml
 # ELASTICSEARCH URL
-sed -ri "s|elasticsearch.url:[^\r\n]*|elasticsearch.url: https://$ELASTICSEARCH_HOST:$ELASTICSEARCH_PORT|" /etc/kibana/kibana.yml
+sed -ri "s|elasticsearch.url:[^\r\n]*|elasticsearch.url: $ELASTICSEARCH_PROTOCOL://$ELASTICSEARCH_HOST:$ELASTICSEARCH_PORT|" /etc/kibana/kibana.yml
 # SSL
 sed -ri "s|elasticsearch.ssl.verify:[^\r\n]*|elasticsearch.ssl.verify: true|" /etc/kibana/kibana.yml
 sed -ri "s|elasticsearch.ssl.ca:[^\r\n]*|elasticsearch.ssl.ca: /etc/elasticsearch/searchguard/ssl/ca/root-ca.pem|" /etc/kibana/kibana.yml

--- a/src/miscellaneous/wait_for_elasticsearch.sh
+++ b/src/miscellaneous/wait_for_elasticsearch.sh
@@ -3,7 +3,7 @@
 RET=1
 while [[ RET -ne 0 ]]; do
    echo "Stalling for Elasticsearch..."
-   curl -XGET -k -u "kibana:$KIBANA_PWD" "https://$ELASTICSEARCH_HOST:$ELASTICSEARCH_PORT/" >/dev/null 2>&1
+   curl -XGET -k -u "kibana:$KIBANA_PWD" "$ELASTICSEARCH_PROTOCOL://$ELASTICSEARCH_HOST:$ELASTICSEARCH_PORT/" >/dev/null 2>&1
    RET=$?
    sleep 5
 done


### PR DESCRIPTION
We using search guard only for user/pass auth and we still using http (next step will move https :) ) 

meanwhile adding support to choose the elastic search http or https .
